### PR TITLE
Use fog-cosmic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,13 +6,14 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', tag: 'v2.0.3'
+  gem 'vagrant', git: 'https://github.com/hashicorp/vagrant.git', ref: "v2.2.4"
   gem 'coveralls', require: false
-  gem 'simplecov', require: false
+  gem 'pry'
   gem 'rspec-core'
   gem 'rspec-expectations'
   gem 'rspec-its'
   gem 'rspec-mocks'
+  gem 'simplecov', require: false
 end
 
 group :plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,25 @@
 GIT
-  remote: https://github.com/mitchellh/vagrant.git
-  revision: 94fd69e3c081cc29c738186529a7037bb9057907
-  tag: v2.0.3
+  remote: https://github.com/hashicorp/vagrant.git
+  revision: 25e11650c3c6b1a2d461ef055aabacb8562b265b
+  ref: v2.2.4
   specs:
-    vagrant (2.0.3)
+    vagrant (2.2.4)
+      bcrypt_pbkdf (~> 1.0.0)
       childprocess (~> 0.6.0)
+      ed25519 (~> 1.2.4)
       erubis (~> 2.7.0)
       hashicorp-checkpoint (~> 0.1.5)
-      i18n (>= 0.6.0, <= 0.8.0)
+      i18n (~> 1.1.1)
       listen (~> 3.1.5)
       log4r (~> 1.1.9, < 1.1.11)
       net-scp (~> 1.2.0)
       net-sftp (~> 2.1)
-      net-ssh (~> 4.2.0)
+      net-ssh (~> 5.1.0)
       rb-kqueue (~> 0.2.0)
       rest-client (>= 1.6.0, < 3.0)
       ruby_dep (<= 1.3.1)
+      rubyzip (~> 1.2.2)
+      vagrant_cloud (~> 2.0.2)
       wdm (~> 0.1.0)
       winrm (~> 2.1)
       winrm-elevated (~> 1.1)
@@ -25,215 +29,58 @@ PATH
   remote: .
   specs:
     vagrant-cosmic (1.5.2)
-      fog (>= 1.32.0)
-      fog-xml (>= 0.1.2)
+      fog-cosmic (~> 0.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.6)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
-    builder (3.2.3)
+    bcrypt_pbkdf (1.0.1)
+    builder (3.2.4)
     childprocess (0.6.3)
       ffi (~> 1.0, >= 1.0.11)
-    coveralls (0.7.2)
+    coderay (1.1.2)
+    concurrent-ruby (1.1.6)
+    coveralls (0.7.1)
       multi_json (~> 1.3)
-      rest-client (= 1.6.7)
+      rest-client
       simplecov (>= 0.7)
-      term-ansicolor (= 1.2.2)
-      thor (= 0.18.1)
-    declarative (0.0.10)
-    declarative-option (0.1.0)
+      term-ansicolor
+      thor
     diff-lcs (1.3)
-    docile (1.3.0)
-    dry-inflector (0.1.2)
+    docile (1.3.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    ed25519 (1.2.4)
+    erubi (1.9.0)
     erubis (2.7.0)
-    excon (0.67.0)
-    faraday (0.15.4)
-      multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (2.1.0)
-      fog-aliyun (>= 0.1.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (~> 0.4)
-      fog-cloudatcost (~> 0.1.0)
-      fog-core (~> 1.45)
-      fog-digitalocean (>= 0.3.0)
-      fog-dnsimple (~> 1.0)
-      fog-dynect (~> 0.0.2)
-      fog-ecloud (~> 0.1)
-      fog-google (~> 1.0)
-      fog-internet-archive
-      fog-joyent
-      fog-json
-      fog-local
-      fog-openstack
-      fog-ovirt
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-rackspace
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-vsphere (>= 0.4.0)
-      fog-xenserver
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      json (~> 2.0)
-    fog-aliyun (0.3.4)
-      fog-core
-      fog-json
-      ipaddress (~> 0.8)
-      xml-simple (~> 1.1)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (2.0.1)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-brightbox (0.16.1)
-      dry-inflector
-      fog-core
-      fog-json
-      mime-types
-    fog-cloudatcost (0.1.2)
-      fog-core (~> 1.36)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-core (1.45.0)
+    excon (0.72.0)
+    ffi (1.12.2)
+    fog-core (2.2.0)
       builder
-      excon (~> 0.58)
+      excon (~> 0.71)
       formatador (~> 0.2)
-    fog-digitalocean (0.4.0)
-      fog-core
-      fog-json
-      fog-xml
-      ipaddress (>= 0.5)
-    fog-dnsimple (1.0.0)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-    fog-dynect (0.0.3)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (1.9.1)
-      fog-core (<= 2.1.0)
-      fog-json (~> 1.2)
-      fog-xml (~> 0.1.0)
-      google-api-client (~> 0.23.0)
-    fog-internet-archive (0.0.1)
-      fog-core
-      fog-json
-      fog-xml
-    fog-joyent (0.0.1)
-      fog-core (~> 1.42)
-      fog-json (>= 1.0)
+      mime-types
+    fog-cosmic (0.1.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
     fog-json (1.2.0)
       fog-core
       multi_json (~> 1.10)
-    fog-local (0.6.0)
-      fog-core (>= 1.27, < 3.0)
-    fog-openstack (0.3.10)
-      fog-core (>= 1.45, <= 2.1.0)
-      fog-json (>= 1.0)
-      ipaddress (>= 0.8)
-    fog-ovirt (0.0.1)
-      fog-core (~> 1.45)
-      fog-json
-      fog-xml (~> 0.1.1)
-    fog-powerdns (0.2.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-profitbricks (4.1.1)
-      fog-core (~> 1.42)
-      fog-json (~> 1.0)
-    fog-rackspace (0.1.6)
-      fog-core (>= 1.35)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.8)
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.4)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-vsphere (3.2.0)
-      fog-core
-      rbvmomi (>= 1.9, < 3)
-    fog-xenserver (1.0.0)
-      fog-core
-      fog-xml
-      xmlrpc
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
-    google-api-client (0.23.9)
-      addressable (~> 2.5, >= 2.5.1)
-      googleauth (>= 0.5, < 0.7.0)
-      httpclient (>= 2.8.1, < 3.0)
-      mime-types (~> 3.0)
-      representable (~> 3.0)
-      retriable (>= 2.0, < 4.0)
-      signet (~> 0.9)
-    googleauth (0.6.7)
-      faraday (~> 0.12)
-      jwt (>= 1.4, < 3.0)
-      memoist (~> 0.16)
-      multi_json (~> 1.11)
-      os (>= 0.9, < 2.0)
-      signet (~> 0.7)
-    gssapi (1.2.0)
+    gssapi (1.3.0)
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
     hashicorp-checkpoint (0.1.5)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (0.8.0)
-    ipaddress (0.8.3)
-    json (2.1.0)
-    jwt (2.2.1)
+    i18n (1.1.1)
+      concurrent-ruby (~> 1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -243,98 +90,90 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    memoist (0.16.0)
-    mime-types (3.1)
+    method_source (0.9.2)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2019.1009)
     mini_portile2 (2.4.0)
-    multi_json (1.13.1)
-    multipart-post (2.1.1)
+    multi_json (1.14.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (4.2.0)
-    nokogiri (1.10.4)
+    net-ssh (5.1.0)
+    netrc (0.11.0)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
-    optimist (3.0.0)
-    os (1.0.1)
-    public_suffix (3.1.1)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rake (10.5.0)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     rb-kqueue (0.2.5)
       ffi (>= 0.5.0)
-    rbvmomi (2.2.0)
-      builder (~> 3.0)
-      json (>= 1.8)
-      nokogiri (~> 1.5)
-      optimist (~> 3.0)
-    representable (3.0.4)
-      declarative (< 0.1.0)
-      declarative-option (< 0.2.0)
-      uber (< 0.2.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
-    retriable (3.1.2)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-its (1.2.0)
+      rspec-support (~> 3.9.0)
+    rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.7.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
     ruby_dep (1.3.1)
     rubyntlm (0.6.2)
-    rubyzip (1.2.1)
-    signet (0.11.0)
-      addressable (~> 2.3)
-      faraday (~> 0.9)
-      jwt (>= 1.5, < 3.0)
-      multi_json (~> 1.10)
-    simplecov (0.16.1)
+    rubyzip (1.2.4)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
-    thor (0.18.1)
-    tins (0.13.2)
-    uber (0.1.0)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.1)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.0.1)
+    tins (1.24.1)
+      sync
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
+    vagrant_cloud (2.0.3)
+      rest-client (~> 2.0.2)
     wdm (0.1.1)
-    winrm (2.2.3)
+    winrm (2.3.4)
       builder (>= 2.1.2)
-      erubis (~> 2.7)
+      erubi (~> 1.8)
       gssapi (~> 1.2)
       gyoku (~> 1.0)
       httpclient (~> 2.2, >= 2.2.0.2)
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0, >= 0.6.1)
-    winrm-elevated (1.1.0)
+    winrm-elevated (1.2.1)
+      erubi (~> 1.8)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
-    winrm-fs (1.2.0)
-      erubis (~> 2.7)
+    winrm-fs (1.3.3)
+      erubi (~> 1.8)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
       winrm (~> 2.0)
-    xml-simple (1.1.5)
-    xmlrpc (0.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   coveralls
+  pry
   rake (~> 10.5, >= 10.4)
   rspec-core
   rspec-expectations
@@ -345,4 +184,4 @@ DEPENDENCIES
   vagrant-cosmic!
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This is a fork of [mitchellh AWS Provider](https://github.com/mitchellh/vagrant-aws/).
 
-This is a [Vagrant](http://www.vagrantup.com) 1.5+ plugin that adds a `cosmic`
+This is a [Vagrant](http://www.vagrantup.com) 2.2+ plugin that adds a `cosmic`
 provider to Vagrant for use with [Cosmic](https://github.com/MissionCriticalCloud/cosmic).
 
 ## Features
@@ -19,7 +19,7 @@ provider to Vagrant for use with [Cosmic](https://github.com/MissionCriticalClou
 
 ## Usage
 
-Install using standard Vagrant 1.1+ plugin installation methods. After
+Install using standard Vagrant 2.2+ plugin installation methods. After
 installing, `vagrant up` and specify the `cosmic` provider. An example is
 shown below.
 

--- a/functional-tests/basic/Vagrantfile.basic_networking
+++ b/functional-tests/basic/Vagrantfile.basic_networking
@@ -30,16 +30,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cosmic.network_type          = "Ignored"
     cosmic.ssh_key               = ENV['SSH_KEY'] unless ENV['SSH_KEY'].nil?
     cosmic.ssh_user              = ENV['SSH_USER'] unless ENV['SSH_USER'].nil?
-
-    cosmic.security_groups       = [{
-                                                :name         => "Awesome_security_group1",
-                                                :description  => "Created from the Vagrantfile",
-                                                :rules        => [{:type => "ingress", :protocol => "TCP", :startport => 23, :endport => 23, :cidrlist => "0.0.0.0/0"}]
-                                        },
-                                        {
-                                                :name         => "Awesome_security_group2",
-                                                :description  => "Created from the Vagrantfile",
-                                                :rules        => [{:type => "ingress", :protocol => "TCP", :startport => 22, :endport => 22, :cidrlist => "0.0.0.0/0"}]
-                                        }]
   end
 end

--- a/functional-tests/basic/basic_spec.rb
+++ b/functional-tests/basic/basic_spec.rb
@@ -1,20 +1,14 @@
 describe 'Basic Network' do
-  it 'starts Linux VM with security groups' do
+  it 'starts a Linux VM' do
     expect(`vagrant up`).to include(
-      'Security Group Awesome_security_group1 created with ID',
-      'Security Group Awesome_security_group2 created with ID',
-      'Security Group: Awesome_security_group1 (',
-      'Security Group: Awesome_security_group2 (',
       'Network name or id will be ignored',
       'Machine is booted and ready for use!'
     )
     expect($?.exitstatus).to eq(0)
   end
-  it 'destroys Linux with security groups' do
+  it 'destroys a Linux VM' do
     expect(`vagrant destroy --force`).to include(
-      'Terminating the instance...',
-      'Deleted ingress rules',
-      'Deleted egress rules'
+      'Terminating the instance...'
     )
     expect($?.exitstatus).to eq(0)
   end

--- a/functional-tests/networking/Vagrantfile.advanced_networking
+++ b/functional-tests/networking/Vagrantfile.advanced_networking
@@ -57,14 +57,6 @@ networks.each_pair do |net_name, net_options|
       ],
       # Trusted network as array, instead of string. Add some networks to make sure it's an (multi element) Array
       pf_trusted_networks: [ENV['SOURCE_CIDR'], ',172.31.1.172/32', '172.31.1.173/32'],
-      # Ignore security groups
-      security_groups: [{
-                            :name => "Awesome_security_group",
-                            :description => "Created from the Vagrantfile",
-                            :rules => [{:type => "ingress", :protocol => "TCP", :startport => 22, :endport => 22, :cidrlist => "0.0.0.0/0"}]
-                        }],
-      # Ignore security groups
-      security_group_names: ['default', 'Awesome_security_group'],
     }
 
     machines["#{net_name}box#{box_number+=1}"] = {
@@ -104,11 +96,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |global_config|
         cosmic.pf_public_port = options[:pf_public_port]    unless options[:pf_public_port].nil?
         cosmic.pf_private_port = options[:pf_private_port]  unless options[:pf_private_port].nil?
         cosmic.pf_open_firewall = false
-
-        # With Advanced networking, following Basic networking features should be ignored
-        cosmic.security_groups = options[:security_groups]            unless options[:security_groups].nil?
-        cosmic.security_group_names = options[:security_group_names]  unless options[:security_group_names].nil?
-        # With Advanced networking, following Basic networking features should be ignored
 
         cosmic.pf_trusted_networks = options[:pf_trusted_networks]      unless options[:pf_trusted_networks].nil?
         cosmic.firewall_rules = options[:firewall_rules]                unless options[:firewall_rules].nil?

--- a/lib/vagrant-cosmic/action/connect_cosmic.rb
+++ b/lib/vagrant-cosmic/action/connect_cosmic.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require 'fog/cosmic'
 require 'log4r'
 
 module VagrantPlugins

--- a/lib/vagrant-cosmic/action/read_transport_info.rb
+++ b/lib/vagrant-cosmic/action/read_transport_info.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
           if not pf_ip_address and pf_ip_address_id and pf_public_port
             begin
               response = cosmic.list_public_ip_addresses({:id => pf_ip_address_id})
-            rescue Fog::Compute::Cosmic::Error => e
+            rescue Fog::Cosmic::Compute::Error => e
               raise Errors::FogError, :message => e.message
             end
 

--- a/lib/vagrant-cosmic/action/run_instance.rb
+++ b/lib/vagrant-cosmic/action/run_instance.rb
@@ -254,18 +254,18 @@ module VagrantPlugins
 
             @server = @env[:cosmic_compute].servers.create(options)
             @server_job_id = @server.job_id
-          rescue Fog::Compute::Cosmic::NotFound => e
+          rescue Fog::Cosmic::Compute::NotFound => e
             # Invalid subnet doesn't have its own error so we catch and
             # check the error message here.
             # XXX FIXME vpc?
             if e.message =~ /subnet ID/
-              raise Errors::FogError,
+              raise Fog::Cosmic::Compute::Error,
                     :message => "Subnet ID not found: #{@networks.map(&:id).compact.join(",")}"
             end
 
             raise
-          rescue Fog::Compute::Cosmic::Error => e
-            raise Errors::FogError, :message => e.message
+          rescue Fog::Cosmic::Compute::Error => e
+            raise Fog::Cosmic::Compute::Error, :message => e.message
           end
 
           @env[:machine].id = @server.id
@@ -352,8 +352,8 @@ module VagrantPlugins
               @env[:ui].warn(" -- Failed to enable static nat: #{resp['enablestaticnatresponse']['errortext']}")
               return
             end
-          rescue Fog::Compute::Cosmic::Error => e
-            raise Errors::FogError, :message => e.message
+          rescue Fog::Cosmic::Compute::Error => e
+            raise Fog::Cosmic::Compute::Error, :message => e.message
           end
 
           # Save ipaddress id to the data dir so it can be disabled when the instance is destroyed
@@ -442,11 +442,11 @@ module VagrantPlugins
                   f.write("#{rule[:publicport]}")
                 end
               end
-            rescue Errors::FogError => e
+            rescue Fog::Cosmic::Compute::Error => e
               if pf_public_port.nil? && !(e.message =~ /The range specified,.*conflicts with rule.*which has/).nil?
                 raise DuplicatePFRule, :message => e.message
               else
-                raise Errors::FogError, :message => e.message
+                raise Fog::Cosmic::Compute::Error, :message => e.message
               end
             end
           end
@@ -493,8 +493,8 @@ module VagrantPlugins
                 sleep 2
               end
             end
-          rescue Fog::Compute::Cosmic::Error => e
-            raise Errors::FogError, :message => e.message
+          rescue Fog::Cosmic::Compute::Error => e
+            raise Fog::Cosmic::Compute::Error, :message => e.message
           end
 
           store_port_forwarding_rules(port_forwarding_rule)
@@ -722,13 +722,13 @@ module VagrantPlugins
                 sleep 2
               end
             end
-          rescue Fog::Compute::Cosmic::Error => e
+          rescue Fog::Cosmic::Compute::Error => e
             if e.message =~ /The range specified,.*conflicts with rule/
               @env[:ui].warn(" -- Failed to create firewall rule: #{e.message}")
             elsif e.message =~ /Default ACL cannot be modified/
               @env[:ui].warn(" -- Failed to create network acl: #{e.message}: #{acl_name}")
             else
-              raise Errors::FogError, :message => e.message
+              raise Fog::Cosmic::Compute::Error, :message => e.message
             end
           end
           firewall_rule

--- a/lib/vagrant-cosmic/action/start_instance.rb
+++ b/lib/vagrant-cosmic/action/start_instance.rb
@@ -47,7 +47,7 @@ module VagrantPlugins
                    :timeout => domain_config.instance_ready_timeout
               end
             end
-          rescue Fog::Compute::Cosmic::Error => e
+          rescue Fog::Cosmic::Compute::Error => e
             raise Errors::FogError, :message => e.message
           end
 

--- a/lib/vagrant-cosmic/action/terminate_instance.rb
+++ b/lib/vagrant-cosmic/action/terminate_instance.rb
@@ -66,7 +66,7 @@ module VagrantPlugins
                 resp = env[:cosmic_compute].detach_volume({:id => volume_id})
                 job_id = resp['detachvolumeresponse']['jobid']
                 wait_for_job_ready(env, job_id)
-              rescue Fog::Compute::Cosmic::Error => e
+              rescue Fog::Cosmic::Compute::Error => e
                 if e.message =~ /Unable to execute API command detachvolume.*entity does not exist/
                   env[:ui].warn(I18n.t('vagrant_cosmic.detach_volume_failed', message: e.message))
                 else
@@ -98,13 +98,13 @@ module VagrantPlugins
                 end
                 env[:ui].info('Deleted egress rules')
 
-              rescue Fog::Compute::Cosmic::Error => e
+              rescue Fog::Cosmic::Compute::Error => e
                 raise Errors::FogError, :message => e.message
               end
 
               begin
                 env[:cosmic_compute].delete_security_group({:id => security_group_id})
-              rescue Fog::Compute::Cosmic::Error => e
+              rescue Fog::Cosmic::Compute::Error => e
                 env[:ui].warn("Couldn't delete group right now.")
                 env[:ui].warn('Waiting 30 seconds to retry')
                 sleep 30
@@ -127,7 +127,7 @@ module VagrantPlugins
             begin
               response = env[:cosmic_compute].delete_ssh_key_pair(name: sshkeyname)
               env[:ui].warn(I18n.t('vagrant_cosmic.ssh_key_pair_no_success_removing', name: sshkeyname)) unless response['deletesshkeypairresponse']['success'] == 'true'
-            rescue Fog::Compute::Cosmic::Error => e
+            rescue Fog::Cosmic::Compute::Error => e
               env[:ui].warn(I18n.t('vagrant_cosmic.errors.fog_error', :message => e.message))
             end
             sshkeyname_file.delete
@@ -149,7 +149,7 @@ module VagrantPlugins
                 resp = env[:cosmic_compute].delete_port_forwarding_rule({:id => rule_id})
                 job_id = resp['deleteportforwardingruleresponse']['jobid']
                 wait_for_job_ready(env, job_id)
-              rescue Fog::Compute::Cosmic::Error => e
+              rescue Fog::Cosmic::Compute::Error => e
                 if e.message =~ /Unable to execute API command deleteportforwardingrule.*entity does not exist/
                   env[:ui].warn(" -- Failed to delete portforwarding rule: #{e.message}")
                 else
@@ -183,7 +183,7 @@ module VagrantPlugins
                 resp = env[:cosmic_compute].request(options)
                 job_id = resp['disablestaticnatresponse']['jobid']
                 wait_for_job_ready(env, job_id)
-              rescue Fog::Compute::Cosmic::Error => e
+              rescue Fog::Cosmic::Compute::Error => e
                 raise Errors::FogError, :message => e.message
               end
             end
@@ -216,7 +216,7 @@ module VagrantPlugins
                 resp = env[:cosmic_compute].request(options)
                 job_id = resp[response_string]['jobid']
                 wait_for_job_ready(env, job_id)
-              rescue Fog::Compute::Cosmic::Error => e
+              rescue Fog::Cosmic::Compute::Error => e
                 if e.message =~ /Unable to execute API command deletefirewallrule.*entity does not exist/
                   env[:ui].warn(" -- Failed to delete #{type_string}: #{e.message}")
                 else

--- a/lib/vagrant-cosmic/config.rb
+++ b/lib/vagrant-cosmic/config.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
            template_id template_name zone_id zone_name keypair pf_ip_address_id pf_ip_address pf_public_port
            pf_public_rdp_port pf_private_port pf_trusted_networks display_name group user_data ssh_key ssh_user
            ssh_network_id ssh_network_name vm_user vm_password private_ip_address).freeze
-      INSTANCE_VAR_DEFAULT_EMPTY_ARRAY = %w(static_nat port_forwarding_rules firewall_rules security_group_ids security_group_names security_groups).freeze
+      INSTANCE_VAR_DEFAULT_EMPTY_ARRAY = %w(static_nat port_forwarding_rules firewall_rules).freeze
 
       # Cosmic API host.
       #
@@ -183,25 +183,6 @@ module VagrantPlugins
       #
       # @return [Array]
       attr_accessor :firewall_rules
-
-      # comma separated list of security groups id that going
-      # to be applied to the virtual machine.
-      #
-      # @return [Array]
-      attr_accessor :security_group_ids
-
-      # comma separated list of security groups name that going
-      # to be applied to the virtual machine.
-      #
-      # @return [Array]
-      attr_accessor :security_group_names
-
-      # comma separated list of security groups
-      # (hash with ingress/egress rules)
-      # to be applied to the virtual machine.
-      #
-      # @return [Array]
-      attr_accessor :security_groups
 
       # display name for the instance
       #

--- a/lib/vagrant-cosmic/service/cosmic_resource_service.rb
+++ b/lib/vagrant-cosmic/service/cosmic_resource_service.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
           options = options.merge({'id' => resource_id})
           begin
             full_response = translate_from_to(resource_type, options)
-          rescue Fog::Compute::Cosmic::BadRequest => e
+          rescue Fog::Cosmic::Compute::BadRequest => e
             raise CosmicResourceNotFound.new("No Name found for #{resource_type} with UUID '#{resource_id}', #{e.class.to_s} reports:\n #{e.message}")
           end
           @resource_details = full_response[0]

--- a/spec/vagrant-cosmic/action/retrieve_public_ip_port_spec.rb
+++ b/spec/vagrant-cosmic/action/retrieve_public_ip_port_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'vagrant-cosmic/action/read_transport_info'
 require 'vagrant-cosmic/config'
-require 'fog'
+require 'fog/cosmic'
 
 describe VagrantPlugins::Cosmic::Action::ReadTransportInfo do
   let(:action) {VagrantPlugins::Cosmic::Action::ReadTransportInfo.new }
@@ -9,7 +9,7 @@ describe VagrantPlugins::Cosmic::Action::ReadTransportInfo do
   describe '#retrieve_public_ip_port' do
     subject { action.retrieve_public_ip_port(cosmic_compute, domain_config, machine) }
 
-    let(:cosmic_compute) { double('Fog::Compute::Cosmic') }
+    let(:cosmic_compute) { double('Fog::Cosmic::Compute') }
     let(:machine) { double('Vagrant::Machine')}
 
     let(:data_dir) { double('Pathname') }

--- a/spec/vagrant-cosmic/action/run_instance_spec.rb
+++ b/spec/vagrant-cosmic/action/run_instance_spec.rb
@@ -3,7 +3,7 @@ require 'vagrant-cosmic/action/run_instance'
 require 'vagrant-cosmic/config'
 
 require 'vagrant'
-require 'fog'
+require 'fog/cosmic'
 
 describe VagrantPlugins::Cosmic::Action::RunInstance do
   let(:action) { VagrantPlugins::Cosmic::Action::RunInstance.new(app, env) }
@@ -224,9 +224,9 @@ describe VagrantPlugins::Cosmic::Action::RunInstance do
     let(:file) { double('File') }
     let(:communicator) { double('VagrantPlugins::CommunicatorSSH::Communicator') }
     let(:communicator_config) { double('VagrantPlugins::...::...Config') }
-    let(:cosmic_compute) { double('Fog::Compute::Cosmic') }
-    let(:servers) { double('Fog::Compute::Cosmic::Servers') }
-    let(:server) { double('Fog::Compute::Cosmic::Server') }
+    let(:cosmic_compute) { double('Fog::Cosmic::Compute') }
+    let(:servers) { double('Fog::Cosmic::Compute::Servers') }
+    let(:server) { double('Fog::Cosmic::Compute::Server') }
     let(:ui) { double('Vagrant::UI::Prefixed') }
     let(:root_path) { double('Pathname') }
     let(:env) do
@@ -239,7 +239,7 @@ describe VagrantPlugins::Cosmic::Action::RunInstance do
     end
 
     let(:cosmic_zone) do
-      instance_double('Fog::Compute::Cosmic::Zone',
+      instance_double('Fog::Cosmic::Compute::Zone',
                       id: ZONE_ID,
                       name: ZONE_NAME,
                       network_type: network_type,
@@ -411,7 +411,7 @@ describe VagrantPlugins::Cosmic::Action::RunInstance do
       context 'with additional data disk' do
         let(:disk_offering_name) { DISK_OFFERING_NAME }
         let(:create_servers_parameters) { super().merge('disk_offering_id' => DISK_OFFERING_ID) }
-        let(:volume) { double('Fog::Compute::Cosmic::Volume') }
+        let(:volume) { double('Fog::Cosmic::Compute::Volume') }
 
         before(:each) do
           allow(cosmic_compute).to receive(:send).with(:list_disk_offerings, listall: true, name: DISK_OFFERING_NAME)
@@ -511,7 +511,7 @@ describe VagrantPlugins::Cosmic::Action::RunInstance do
               expect(cosmic_compute).to receive(:create_port_forwarding_rule)
                 .with(create_port_forwarding_rule_parameters.merge(publicport: PF_RANDOM_START - 1))
                 .and_raise(
-                  Fog::Compute::Cosmic::Error,
+                  Fog::Cosmic::Compute::Error,
                   'The range specified, CONFLICTINGRANGE, conflicts with rule SOMERULE which has THESAME'
                 )
             end

--- a/spec/vagrant-cosmic/action/terminate_instance_spec.rb
+++ b/spec/vagrant-cosmic/action/terminate_instance_spec.rb
@@ -202,47 +202,6 @@ describe VagrantPlugins::Cosmic::Action::TerminateInstance do
           should eq true
         end
       end
-
-      context 'with security groups removal' do
-        let(:security_group_path) { double('Pathname') }
-        let(:cosmic_securitygroups) { double('Fog::Cosmic::Compute::SecurityGroups') }
-        let(:cosmic_securitygroup) { double('Fog::Cosmic::Compute::SecurityGroup') }
-        RULE_ID_INGRESS = 'UUID of Ingress Rule'.freeze
-        RULE_ID_EGRESS = 'UUID of Egress Rule'.freeze
-
-        before(:each) do
-          expect(data_dir).to receive(:join).with('security_groups').and_return(security_group_path)
-          expect(security_group_path).to receive(:file?).and_return(true)
-          allow(File).to receive(:read)
-            .and_return("#{SECURITY_GROUP_ID}\n")
-
-          expect(cosmic_compute).to receive(:security_groups).and_return(cosmic_securitygroups)
-          expect(cosmic_securitygroups).to receive(:get)
-            .with(SECURITY_GROUP_ID)
-            .and_return(cosmic_securitygroup)
-
-          expect(cosmic_securitygroup).to receive(:ingress_rules)
-            .and_return([{ 'ruleid' => RULE_ID_INGRESS }])
-          expect(cosmic_compute).to receive(:revoke_security_group_ingress)
-            .with(id: RULE_ID_INGRESS)
-            .and_return('revokesecuritygroupingressresponse' => { 'jobid' => JOB_ID })
-
-          expect(cosmic_securitygroup).to receive(:egress_rules)
-            .and_return([{ 'ruleid' => RULE_ID_EGRESS }])
-          expect(cosmic_compute).to receive(:revoke_security_group_egress)
-            .with(id: RULE_ID_EGRESS)
-            .and_return('revokesecuritygroupegressresponse' => { 'jobid' => JOB_ID })
-
-          expect(cosmic_compute).to receive(:delete_security_group)
-            .with(id: SECURITY_GROUP_ID)
-
-          expect(security_group_path).to receive(:delete).and_return(true)
-        end
-
-        it 'destroys a vm' do
-          should eq true
-        end
-      end
     end
   end
 end

--- a/spec/vagrant-cosmic/action/terminate_instance_spec.rb
+++ b/spec/vagrant-cosmic/action/terminate_instance_spec.rb
@@ -3,14 +3,14 @@ require 'vagrant-cosmic/action/terminate_instance'
 require 'vagrant-cosmic/config'
 
 require 'vagrant'
-require 'fog'
+require 'fog/cosmic'
 
 describe VagrantPlugins::Cosmic::Action::TerminateInstance do
   let(:action) { VagrantPlugins::Cosmic::Action::TerminateInstance.new(app, env) }
 
   let(:destroy_server_response) { { id: JOB_ID } }
 
-  let(:cs_job) { double('Fog::Compute::Cosmic::Job') }
+  let(:cs_job) { double('Fog::Cosmic::Compute::Job') }
 
   let(:fake_job_result) do
     {
@@ -47,9 +47,9 @@ describe VagrantPlugins::Cosmic::Action::TerminateInstance do
     let(:a_path) { double('Pathname') }
     let(:file) { double('File') }
 
-    let(:cosmic_compute) { double('Fog::Compute::Cosmic') }
-    let(:servers) { double('Fog::Compute::Cosmic::Servers') }
-    let(:server) { double('Fog::Compute::Cosmic::Server') }
+    let(:cosmic_compute) { double('Fog::Cosmic::Compute') }
+    let(:servers) { double('Fog::Cosmic::Compute::Servers') }
+    let(:server) { double('Fog::Cosmic::Compute::Server') }
     let(:ui) { double('Vagrant::UI::Prefixed') }
     let(:root_path) { double('Pathname') }
     let(:env) do
@@ -205,8 +205,8 @@ describe VagrantPlugins::Cosmic::Action::TerminateInstance do
 
       context 'with security groups removal' do
         let(:security_group_path) { double('Pathname') }
-        let(:cosmic_securitygroups) { double('Fog::Compute::Cosmic::SecurityGroups') }
-        let(:cosmic_securitygroup) { double('Fog::Compute::Cosmic::SecurityGroup') }
+        let(:cosmic_securitygroups) { double('Fog::Cosmic::Compute::SecurityGroups') }
+        let(:cosmic_securitygroup) { double('Fog::Cosmic::Compute::SecurityGroup') }
         RULE_ID_INGRESS = 'UUID of Ingress Rule'.freeze
         RULE_ID_EGRESS = 'UUID of Egress Rule'.freeze
 

--- a/spec/vagrant-cosmic/config_spec.rb
+++ b/spec/vagrant-cosmic/config_spec.rb
@@ -43,11 +43,8 @@ describe VagrantPlugins::Cosmic::Config do
     its("pf_trusted_networks")    { should be_nil  }
     its("port_forwarding_rules")  { should == []   }
     its("firewall_rules")         { should == []   }
-    its("security_group_ids")     { should == []   }
     its("display_name")           { should be_nil  }
     its("group")                  { should be_nil  }
-    its("security_group_names")   { should == []   }
-    its("security_groups")        { should == []   }
     its("user_data")              { should be_nil  }
     its("ssh_key")                { should be_nil  }
     its("ssh_user")               { should be_nil  }
@@ -153,11 +150,8 @@ describe VagrantPlugins::Cosmic::Config do
     let(:config_pf_trusted_networks)    { ["foo", "bar"] }
     let(:config_port_forwarding_rules)  { [{:foo => "bar"}, {:bar => "foo"}] }
     let(:config_firewall_rules)         { [{:foo => "bar"}, {:bar => "foo"}] }
-    let(:config_security_group_ids)     { ["foo", "bar"] }
     let(:config_display_name)           { "foo" }
     let(:config_group)                  { "foo" }
-    let(:config_security_group_names)   { ["foo", "bar"] }
-    let(:config_security_groups)        { [{:foo => "bar"}, {:bar => "foo"}] }
     let(:config_ssh_key)                { "./foo.pem" }
     let(:config_ssh_user)               { "foo" }
     let(:config_vm_user)                { "foo" }
@@ -193,11 +187,8 @@ describe VagrantPlugins::Cosmic::Config do
       instance.pf_trusted_networks    = config_pf_trusted_networks
       instance.port_forwarding_rules  = config_port_forwarding_rules
       instance.firewall_rules         = config_firewall_rules
-      instance.security_group_ids     = config_security_group_ids
       instance.display_name           = config_display_name
       instance.group                  = config_group
-      instance.security_group_names   = config_security_group_names
-      instance.security_groups        = config_security_groups
       instance.ssh_key                = config_ssh_key
       instance.ssh_user               = config_ssh_user
       instance.vm_user                = config_vm_user
@@ -250,11 +241,8 @@ describe VagrantPlugins::Cosmic::Config do
       its("pf_open_firewall")       { should == config_pf_open_firewall }
       its("port_forwarding_rules")  { should == config_port_forwarding_rules }
       its("firewall_rules")         { should == config_firewall_rules }
-      its("security_group_ids")     { should == config_security_group_ids }
       its("display_name")           { should == config_display_name }
       its("group")                  { should == config_group }
-      its("security_group_names")   { should == config_security_group_names }
-      its("security_groups")        { should == config_security_groups }
       its("ssh_key")                { should == config_ssh_key }
       its("ssh_user")               { should == config_ssh_user }
       its("vm_user")                { should == config_vm_user }
@@ -306,11 +294,8 @@ describe VagrantPlugins::Cosmic::Config do
       its("pf_trusted_networks")    { should == config_pf_trusted_networks}
       its("port_forwarding_rules")  { should == config_port_forwarding_rules }
       its("firewall_rules")         { should == config_firewall_rules }
-      its("security_group_ids")     { should == config_security_group_ids }
       its("display_name")           { should == config_display_name }
       its("group")                  { should == config_group }
-      its("security_group_names")   { should == config_security_group_names }
-      its("security_groups")        { should == config_security_groups }
       its("ssh_key")                { should == config_ssh_key }
       its("ssh_user")               { should == config_ssh_user }
       its("vm_user")                { should == config_vm_user }

--- a/spec/vagrant-cosmic/service/cosmic_resource_service_spec.rb
+++ b/spec/vagrant-cosmic/service/cosmic_resource_service_spec.rb
@@ -6,7 +6,7 @@ include VagrantPlugins::Cosmic::Model
 include VagrantPlugins::Cosmic::Service
 
 describe CosmicResourceService do
-  let(:cosmic_compute) { double('Fog::Compute::Cosmic') }
+  let(:cosmic_compute) { double('Fog::Cosmic::Compute') }
   let(:ui) { double('Vagrant::UI') }
   let(:service) { CosmicResourceService.new(cosmic_compute, ui) }
 

--- a/vagrant-cosmic.gemspec
+++ b/vagrant-cosmic.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'vagrant-cosmic'
 
-  s.add_runtime_dependency 'fog', '>= 1.32.0'
-  s.add_runtime_dependency 'fog-xml', '>= 0.1.2'
+  s.add_runtime_dependency 'fog-cosmic', '~> 0.1.0'
 
   s.add_development_dependency 'rake',                '>= 10.4', '~> 10.5'
   s.add_development_dependency 'rspec-core',          '~> 2.14', '>= 2.14.7'


### PR DESCRIPTION
Switches to newer fog-cosmic gem to do all Cosmic communications.

Doing so needed some refactoring as well as bumping the vagrant ref to 2.2.4 (newer versions aren't able to run `vagrant` via Bundler).

Unit tests are working again.

Could do a `bundle exec vagrant up --provider=cosmic` and `bundle exec vagrant destroy` successfully after removing security group support as that's been removed from fog-cosmic (but was still present in vagrant-cloudstack it seems).

This should also fix most of security/dependency warnings from dependabot.