### PR TITLE
Add support for affinity groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the `vagrant-cosmic` plugin.
 
+## Unreleased
+
+- Added support to provision instances in an already existing Affinity Group(s).
+
 ## 0.1.0 (2020-02-25)
 
 - Forked plugin from [MissionCriticalCloud/vagrant-cloudstack](https://github.com/MissionCriticalCloud/vagrant-cloudstack) and renamed to `vagrant-cosmic`

--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `scheme` - Cosmic API scheme _(defaults: https (thanks to the resolution order in fog))_
 * `api_key` - The API key for accessing Cosmic
 * `secret_key` - The secret key for accessing Cosmic
-* `instance_ready_timeout` - The number of seconds to wait for the instance
-  to become "ready" in Cosmic. Defaults to 120 seconds.
+* `affinity_group_id` - An affinity group uuid or array of uuid(s) to add the instance to
+* `affinity_group_name` - An affinity group name or array of name(s) to add the instance to
 * `domain_id` - Domain id to launch the instance into
+* `instance_ready_timeout` - The number of seconds to wait for the instance to become "ready" in Cosmic. Defaults to 120 seconds.
 * `network_id` - Network uuid(s) that the instance should use
   * `network_id` is single value (e.g. `"AAAA"`) or multiple values (e.g. `["AAAA", "BBBB"]`)
 * `network_name` - Network name(s) that the instance should use

--- a/lib/vagrant-cosmic/action/run_instance.rb
+++ b/lib/vagrant-cosmic/action/run_instance.rb
@@ -82,7 +82,7 @@ module VagrantPlugins
 
         def sanitize_domain_config
           # Accept a single entry as input, convert it to array
-          @domain_config.pf_trusted_networks = [@domain_config.pf_trusted_networks] if @domain_config.pf_trusted_networks
+          @domain_config.pf_trusted_networks = Array(@domain_config.pf_trusted_networks) if @domain_config.pf_trusted_networks
 
           if @domain_config.network_id.nil?
             # Use names if ids are not present

--- a/lib/vagrant-cosmic/config.rb
+++ b/lib/vagrant-cosmic/config.rb
@@ -9,16 +9,12 @@ module VagrantPlugins
            ssh_network_id ssh_network_name vm_user vm_password private_ip_address).freeze
       INSTANCE_VAR_DEFAULT_EMPTY_ARRAY = %w(static_nat port_forwarding_rules firewall_rules).freeze
 
+      ### API settings
+
       # Cosmic API host.
       #
       # @return [String]
       attr_accessor :host
-
-      # Hostname for the machine instance
-      # This will be passed through to the api.
-      #
-      # @return [String]
-      attr_accessor :name
 
       # Cosmic API path.
       #
@@ -45,15 +41,53 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :secret_key
 
-      # The timeout to wait for an instance to become ready.
+      ### Instance settings
+
+      # Hostname for the machine instance
+      # This will be passed through to the api.
       #
-      # @return [Fixnum]
-      attr_accessor :instance_ready_timeout
+      # @return [String]
+      attr_accessor :name
+
+      # Disk offering uuid to use for the instance
+      #
+      # @return [String]
+      attr_accessor :disk_offering_id
+
+      # Disk offering name to use for the instance
+      #
+      # @return [String]
+      attr_accessor :disk_offering_name
+
+      # display name for the instance
+      #
+      # @return [String]
+      attr_accessor :display_name
 
       # Domain id to launch the instance into.
       #
       # @return [String]
       attr_accessor :domain_id
+
+      # flag to enable/disable expunge vm on destroy
+      #
+      # @return [Boolean]
+      attr_accessor :expunge_on_destroy
+
+      # group for the instance
+      #
+      # @return [String]
+      attr_accessor :group
+
+      # The timeout to wait for an instance to become ready.
+      #
+      # @return [Fixnum]
+      attr_accessor :instance_ready_timeout
+
+      # The name of the keypair to use.
+      #
+      # @return [String]
+      attr_accessor :keypair
 
       # Network uuid(s) that the instance should use
       #
@@ -70,6 +104,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :network_type
 
+      # Private ip for the instance
+      #
+      # @return [String]
+      attr_accessor :private_ip_address
+
       # Project uuid that the instance should belong to
       #
       # @return [String]
@@ -85,15 +124,30 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :service_offering_name
 
-      # Disk offering uuid to use for the instance
+      # The key to be used when loging in to the vm via ssh
       #
       # @return [String]
-      attr_accessor :disk_offering_id
+      attr_accessor :ssh_key
 
-      # Disk offering name to use for the instance
+      # The network_id to be used when loging in to the vm via ssh
       #
       # @return [String]
-      attr_accessor :disk_offering_name
+      attr_accessor :ssh_network_id
+
+      # The network_name to be used when loging in to the vm via ssh
+      #
+      # @return [String]
+      attr_accessor :ssh_network_name
+
+      # The username to be used when loging in to the vm via ssh
+      #
+      # @return [String]
+      attr_accessor :ssh_user
+
+      # Paramters for Static NAT
+      #
+      # @return [String]
+      attr_accessor :static_nat
 
       # Template uuid to use for the instance
       #
@@ -104,6 +158,21 @@ module VagrantPlugins
       #
       # @return [String]
       attr_accessor :template_name
+
+      # The user data string
+      #
+      # @return [String]
+      attr_accessor :user_data
+
+      # The username to be used when loging in to the vm
+      #
+      # @return [String]
+      attr_accessor :vm_password
+
+      # The username to be used when loging in to the vm
+      #
+      # @return [String]
+      attr_accessor :vm_user
 
       # Zone uuid to launch the instance into. If nil, it will
       # launch in default project.
@@ -117,15 +186,20 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :zone_name
 
-      # The name of the keypair to use.
-      #
-      # @return [String]
-      attr_accessor :keypair
+      ### Firewall settings
 
-      # Paramters for Static NAT
+      # comma separated list of firewall rules
+      # (hash with rule parameters)
       #
-      # @return [String]
-      attr_accessor :static_nat
+      # @return [Array]
+      attr_accessor :firewall_rules
+
+      # flag to enable/disable automatic open firewall rule
+      #
+      # @return [Boolean]
+      attr_accessor :pf_open_firewall
+
+      ### Port forward settings
 
       # IP address id to use for port forwarding rule
       #
@@ -162,11 +236,6 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :pf_private_port
 
-      # flag to enable/disable automatic open firewall rule
-      #
-      # @return [Boolean]
-      attr_accessor :pf_open_firewall
-
       # CIDR List string of trusted networks
       #
       # @return [String]
@@ -177,67 +246,6 @@ module VagrantPlugins
       #
       # @return [Array]
       attr_accessor :port_forwarding_rules
-
-      # comma separated list of firewall rules
-      # (hash with rule parameters)
-      #
-      # @return [Array]
-      attr_accessor :firewall_rules
-
-      # display name for the instance
-      #
-      # @return [String]
-      attr_accessor :display_name
-
-      # group for the instance
-      #
-      # @return [String]
-      attr_accessor :group
-
-      # The user data string
-      #
-      # @return [String]
-      attr_accessor :user_data
-
-      # The key to be used when loging in to the vm via ssh
-      #
-      # @return [String]
-      attr_accessor :ssh_key
-
-      # The username to be used when loging in to the vm via ssh
-      #
-      # @return [String]
-      attr_accessor :ssh_user
-
-      # The network_id to be used when loging in to the vm via ssh
-      #
-      # @return [String]
-      attr_accessor :ssh_network_id
-
-      # The network_name to be used when loging in to the vm via ssh
-      #
-      # @return [String]
-      attr_accessor :ssh_network_name
-
-      # The username to be used when loging in to the vm
-      #
-      # @return [String]
-      attr_accessor :vm_user
-
-      # The username to be used when loging in to the vm
-      #
-      # @return [String]
-      attr_accessor :vm_password
-
-      # Private ip for the instance
-      #
-      # @return [String]
-      attr_accessor :private_ip_address
-
-      # flag to enable/disable expunge vm on destroy
-      #
-      # @return [Boolean]
-      attr_accessor :expunge_on_destroy
 
       def initialize(domain_specific = false)
         # Initialize groups in bulk, re-use these groups to set defaults in bulk

--- a/lib/vagrant-cosmic/config.rb
+++ b/lib/vagrant-cosmic/config.rb
@@ -3,10 +3,39 @@ require "vagrant"
 module VagrantPlugins
   module Cosmic
     class Config < Vagrant.plugin("2", :config)
-      INSTANCE_VAR_DEFAULT_NIL = %w(host name path port domain_id network_id network_name project_id service_offering_id service_offering_name
-           template_id template_name zone_id zone_name keypair pf_ip_address_id pf_ip_address pf_public_port
-           pf_public_rdp_port pf_private_port pf_trusted_networks display_name group user_data ssh_key ssh_user
-           ssh_network_id ssh_network_name vm_user vm_password private_ip_address).freeze
+      INSTANCE_VAR_DEFAULT_NIL = %w(affinity_group_id
+                                    affinity_group_name
+                                    display_name
+                                    domain_id
+                                    group
+                                    host
+                                    keypair
+                                    name
+                                    network_id
+                                    network_name
+                                    path
+                                    pf_ip_address
+                                    pf_ip_address_id
+                                    pf_private_port
+                                    pf_public_port
+                                    pf_public_rdp_port
+                                    pf_trusted_networks
+                                    port
+                                    private_ip_address
+                                    project_id
+                                    service_offering_id
+                                    service_offering_name
+                                    ssh_key
+                                    ssh_network_id
+                                    ssh_network_name
+                                    ssh_user
+                                    template_id
+                                    template_name
+                                    user_data
+                                    vm_password
+                                    vm_user
+                                    zone_id
+                                    zone_name).freeze
       INSTANCE_VAR_DEFAULT_EMPTY_ARRAY = %w(static_nat port_forwarding_rules firewall_rules).freeze
 
       ### API settings
@@ -48,6 +77,16 @@ module VagrantPlugins
       #
       # @return [String]
       attr_accessor :name
+
+      # Affinity group ID(s) the instance should be applied to
+      #
+      # @return [String]
+      attr_accessor :affinity_group_id
+
+      # Affinity group name(s) the instance should be applied to
+      #
+      # @return [String]
+      attr_accessor :affinity_group_name
 
       # Disk offering uuid to use for the instance
       #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ Dir["#{__dir__}/vagrant-cosmic/support/**/*.rb"].each { |f| require f }
 SimpleCov.start
 Coveralls.wear!
 
+AFFINITY_GROUP_NAME = 'Affinity Group Name'.freeze
+AFFINITY_GROUP_ID = 'Affinity Group UUID'.freeze
 ZONE_NAME = 'Zone Name'.freeze
 ZONE_ID = 'Zone UUID'.freeze
 SERVICE_OFFERING_NAME = 'Service Offering Name'.freeze


### PR DESCRIPTION
This lets you specify an affinity group name or uuid, or array of names or uuids, of an existing affinity group(s) to attach an instance to during duration.